### PR TITLE
Rebased our patches onto upstream

### DIFF
--- a/marge/app.py
+++ b/marge/app.py
@@ -32,6 +32,7 @@ def time_interval(str_interval):
         ) from err
 
 
+# pylint: disable=too-many-statements
 def _parse_config(args):
 
     def regexp(str_regex):
@@ -188,6 +189,14 @@ def _parse_config(args):
         help='Deprecated; use --ci-timeout.\n',
     )
     parser.add_argument(
+        '--require-ci-run-by-me',
+        action='store_true',
+        help=(
+            'Require a successful CI started by me. Start one if necessary.\n'
+            'The idea is that you can use $GITLAB_USER_LOGIN = marge-bot to run expensive merge-only CI.\n'
+        ),
+    )
+    parser.add_argument(
         '--git-timeout',
         type=time_interval,
         default='120s',
@@ -342,6 +351,7 @@ def main(args=None):
                 use_no_ff_batches=options.use_no_ff_batches,
                 use_merge_commit_batches=options.use_merge_commit_batches,
                 skip_ci_batches=options.skip_ci_batches,
+                require_ci_run_by_me=options.require_ci_run_by_me,
             ),
             batch=options.batch,
             cli=options.cli,

--- a/marge/app.py
+++ b/marge/app.py
@@ -286,9 +286,11 @@ def _parse_config(args):
     cli_args = []
     # pylint: disable=protected-access
     for _, (_, value) in parser._source_to_settings.get(configargparse._COMMAND_LINE_SOURCE_KEY, {}).items():
-        cli_args.extend(value)
+        # remove '=value' from any '--arg=value'
+        args = [a.split('=')[0] for a in value]
+        cli_args.extend(args)
     for bad_arg in ['--auth-token', '--ssh-key']:
-        if any(bad_arg in arg for arg in cli_args):
+        if bad_arg in cli_args:
             raise MargeBotCliArgError('"%s" can only be set via ENV var or config file.' % bad_arg)
     return config
 

--- a/marge/app.py
+++ b/marge/app.py
@@ -5,7 +5,6 @@ An auto-merger of merge requests for GitLab
 import contextlib
 import logging
 import re
-import signal
 import sys
 import tempfile
 from datetime import timedelta
@@ -292,9 +291,8 @@ def _secret_auth_token_and_ssh_key(options):
                 tmp_ssh_key_file.close()
 
 
-
 def main(args=None):
-    error.install_signal_handler();
+    error.install_signal_handler()
     if not args:
         args = sys.argv[1:]
     logging.basicConfig()
@@ -365,8 +363,5 @@ def main(args=None):
             marge_bot = bot.Bot(api=api, config=config)
             marge_bot.start()
         except error.SignalError as exc:
-            logging.info('died on signal: %s' % (exc.signal,))
+            logging.info('died on signal: %s', (exc.signal,))
             sys.exit(exc.signal)
-        except Exception as exc:
-            logging.exception('died on exception')
-            throw

--- a/marge/app.py
+++ b/marge/app.py
@@ -247,6 +247,16 @@ def _parse_config(args):
         action='store_true',
         help='Run marge-bot as a single CLI command, not a service'
     )
+    parser.add_argument(
+        '--ci-timeout-skip',
+        action='store_true',
+        help='Skip to next MR if CI timeout expires (otherwise, give up on MR)'
+    )
+    parser.add_argument(
+        '--skip-pending',
+        action='store_true',
+        help='Skip to next MR if oldest MR is not ready (otherwise, wait until it is)'
+    )
     config = parser.parse_args(args)
 
     if config.use_merge_strategy and config.batch:
@@ -349,6 +359,7 @@ def main(args=None):
                 approval_timeout=options.approval_reset_timeout,
                 embargo=options.embargo,
                 ci_timeout=options.ci_timeout,
+                ci_timeout_skip=options.ci_timeout_skip,
                 fusion=fusion,
                 use_no_ff_batches=options.use_no_ff_batches,
                 use_merge_commit_batches=options.use_merge_commit_batches,
@@ -357,6 +368,7 @@ def main(args=None):
             ),
             batch=options.batch,
             cli=options.cli,
+            skip_pending=options.skip_pending,
         )
 
         try:

--- a/marge/app.py
+++ b/marge/app.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import configargparse
 
 from . import bot
+from . import error
 from . import interval
 from . import gitlab
 from . import user as user_module
@@ -292,18 +293,8 @@ def _secret_auth_token_and_ssh_key(options):
 
 
 
-def handle(sig, _):
-    raise SignalError(sig)
-
-class SignalError(Exception):
-    """Raised on an signal."""
-    def __init__(self, signal):
-        Exception.__init__(self)
-        self.signal = signal
-
-
 def main(args=None):
-    signal.signal(signal.SIGTERM, handle)
+    error.install_signal_handler();
     if not args:
         args = sys.argv[1:]
     logging.basicConfig()
@@ -373,7 +364,7 @@ def main(args=None):
         try:
             marge_bot = bot.Bot(api=api, config=config)
             marge_bot.start()
-        except SignalError as exc:
+        except error.SignalError as exc:
             logging.info('died on signal: %s' % (exc.signal,))
             sys.exit(exc.signal)
         except Exception as exc:

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -1,5 +1,4 @@
 import logging as log
-import os
 import time
 from collections import namedtuple
 from tempfile import TemporaryDirectory

--- a/marge/bot.py
+++ b/marge/bot.py
@@ -1,4 +1,5 @@
 import logging as log
+import os
 import time
 from collections import namedtuple
 from tempfile import TemporaryDirectory

--- a/marge/error.py
+++ b/marge/error.py
@@ -7,11 +7,13 @@ def install_signal_handler():
     """Turn SIGTERM into an exception, so it gets logged."""
     signal.signal(signal.SIGTERM, handle)
 
+
 def handle(sig, _):
     raise SignalError(sig)
 
+
 class SignalError(Exception):
     """Raised on an signal."""
-    def __init__(self, signal):
+    def __init__(self, sig):
         Exception.__init__(self)
-        self.signal = signal
+        self.signal = sig

--- a/marge/error.py
+++ b/marge/error.py
@@ -1,0 +1,17 @@
+"""Exceptions and error handling.
+"""
+import signal
+
+
+def install_signal_handler():
+    """Turn SIGTERM into an exception, so it gets logged."""
+    signal.signal(signal.SIGTERM, handle)
+
+def handle(sig, _):
+    raise SignalError(sig)
+
+class SignalError(Exception):
+    """Raised on an signal."""
+    def __init__(self, signal):
+        Exception.__init__(self)
+        self.signal = signal

--- a/marge/gitlab.py
+++ b/marge/gitlab.py
@@ -16,7 +16,9 @@ class Api:
         headers = {'PRIVATE-TOKEN': self._auth_token}
         if sudo:
             headers['SUDO'] = '%d' % sudo
-        log.debug('REQUEST: %s %s %r %r', method.__name__.upper(), url, headers, command.call_args)
+        cleaned_headers = headers.copy()
+        cleaned_headers['PRIVATE-TOKEN'] = 'xxxx'
+        log.debug('REQUEST: %s %s %r %r', method.__name__.upper(), url, cleaned_headers, command.call_args)
         # Timeout to prevent indefinitely hanging requests. 60s is very conservative,
         # but should be short enough to not cause any practical annoyances. We just
         # crash rather than retry since marge-bot should be run in a restart loop anyway.

--- a/marge/job.py
+++ b/marge/job.py
@@ -199,7 +199,7 @@ class MergeJob:
                 pipeline = Pipeline.start(
                     merge_request.source_project_id, merge_request.source_branch, self._api)
                 log.info('Started pipeline %s', pipeline.id)
-            elif ci_status not in ('pending', 'running'):
+            elif ci_status not in ('pending', 'running', 'created'):
                 log.warning('Suspicious CI status: %r', ci_status)
 
             log.debug('Waiting for %s secs before polling CI status again', waiting_time_in_secs)

--- a/marge/job.py
+++ b/marge/job.py
@@ -139,7 +139,7 @@ class MergeJob:
             )
         return sha
 
-    def get_mr_ci_status(self, merge_request, commit_sha=None):
+    def get_mr_ci_status(self, merge_request, commit_sha=None, ci_run_by_me=False):
         if commit_sha is None:
             commit_sha = merge_request.sha
 
@@ -148,12 +148,14 @@ class MergeJob:
                 merge_request.target_project_id,
                 merge_request.iid,
                 self._api,
+                username=self._user.username if ci_run_by_me else None,
             )
         else:
             pipelines = Pipeline.pipelines_by_branch(
                 merge_request.source_project_id,
                 merge_request.source_branch,
                 self._api,
+                username=self._user.username if ci_run_by_me else None,
             )
         current_pipeline = next(iter(pipeline for pipeline in pipelines if pipeline.sha == commit_sha), None)
 
@@ -172,9 +174,12 @@ class MergeJob:
         if commit_sha is None:
             commit_sha = merge_request.sha
 
+        ci_run_by_me = self._options.require_ci_run_by_me
+
         log.info('Waiting for CI to pass for MR !%s', merge_request.iid)
         while datetime.utcnow() - time_0 < self._options.ci_timeout:
-            ci_status = self.get_mr_ci_status(merge_request, commit_sha=commit_sha)
+            ci_status = self.get_mr_ci_status(
+                merge_request, commit_sha=commit_sha, ci_run_by_me=ci_run_by_me)
             if ci_status == 'success':
                 log.info('CI for MR !%s passed', merge_request.iid)
                 return
@@ -189,7 +194,12 @@ class MergeJob:
             if ci_status == 'canceled':
                 raise CannotMerge('Someone canceled the CI.')
 
-            if ci_status not in ('pending', 'running'):
+            if ci_status is None and ci_run_by_me:
+                log.info('Starting a CI in my name')
+                pipeline = Pipeline.start(
+                    merge_request.source_project_id, merge_request.source_branch, self._api)
+                log.info('Started pipeline %s', pipeline.id)
+            elif ci_status not in ('pending', 'running'):
                 log.warning('Suspicious CI status: %r', ci_status)
 
             log.debug('Waiting for %s secs before polling CI status again', waiting_time_in_secs)
@@ -460,6 +470,7 @@ JOB_OPTIONS = [
     'use_no_ff_batches',
     'use_merge_commit_batches',
     'skip_ci_batches',
+    'require_ci_run_by_me',
 ]
 
 
@@ -476,6 +487,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
             approval_timeout=None, embargo=None, ci_timeout=None, fusion=Fusion.rebase,
             use_no_ff_batches=False, use_merge_commit_batches=False, skip_ci_batches=False,
+            require_ci_run_by_me=False,
     ):
         approval_timeout = approval_timeout or timedelta(seconds=0)
         embargo = embargo or IntervalUnion.empty()
@@ -492,6 +504,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             use_no_ff_batches=use_no_ff_batches,
             use_merge_commit_batches=use_merge_commit_batches,
             skip_ci_batches=skip_ci_batches,
+            require_ci_run_by_me=require_ci_run_by_me,
         )
 
 

--- a/marge/job.py
+++ b/marge/job.py
@@ -205,6 +205,8 @@ class MergeJob:
             log.debug('Waiting for %s secs before polling CI status again', waiting_time_in_secs)
             time.sleep(waiting_time_in_secs)
 
+        if self._options.ci_timeout_skip:
+            raise SkipMerge('CI is taking too long.')
         raise CannotMerge('CI is taking too long.')
 
     def wait_for_merge_status_to_resolve(self, merge_request):
@@ -471,6 +473,7 @@ JOB_OPTIONS = [
     'use_merge_commit_batches',
     'skip_ci_batches',
     'require_ci_run_by_me',
+    'ci_timeout_skip',
 ]
 
 
@@ -485,9 +488,9 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
     def default(
             cls, *,
             add_tested=False, add_part_of=False, add_reviewers=False, reapprove=False,
-            approval_timeout=None, embargo=None, ci_timeout=None, fusion=Fusion.rebase,
-            use_no_ff_batches=False, use_merge_commit_batches=False, skip_ci_batches=False,
-            require_ci_run_by_me=False,
+            approval_timeout=None, embargo=None, ci_timeout=None, ci_timeout_skip=False,
+            fusion=Fusion.rebase, use_no_ff_batches=False, use_merge_commit_batches=False,
+            skip_ci_batches=False, require_ci_run_by_me=False,
     ):
         approval_timeout = approval_timeout or timedelta(seconds=0)
         embargo = embargo or IntervalUnion.empty()
@@ -500,6 +503,7 @@ class MergeJobOptions(namedtuple('MergeJobOptions', JOB_OPTIONS)):
             approval_timeout=approval_timeout,
             embargo=embargo,
             ci_timeout=ci_timeout,
+            ci_timeout_skip=ci_timeout_skip,
             fusion=fusion,
             use_no_ff_batches=use_no_ff_batches,
             use_merge_commit_batches=use_merge_commit_batches,

--- a/marge/job.py
+++ b/marge/job.py
@@ -302,6 +302,7 @@ class MergeJob:
             Fusion.rebase: self._repo.rebase,
             Fusion.merge: self._repo.merge,
             Fusion.gitlab_rebase: self._repo.rebase,  # we rebase locally to know sha
+            Fusion.rebase_then_merge: self._repo.rebase_then_merge,
         }
 
         strategy = strategies[self._options.fusion]
@@ -458,6 +459,7 @@ class Fusion(enum.Enum):
     merge = 0
     rebase = 1
     gitlab_rebase = 2
+    rebase_then_merge = 3
 
 
 JOB_OPTIONS = [

--- a/marge/pipeline.py
+++ b/marge/pipeline.py
@@ -16,6 +16,7 @@ class Pipeline(gitlab.Resource):
             status=None,
             order_by='id',
             sort='desc',
+            username=None,
     ):
         params = {
             'ref': branch if ref is None else ref,
@@ -24,6 +25,8 @@ class Pipeline(gitlab.Resource):
         }
         if status is not None:
             params['status'] = status
+        if username is not None:
+            params['username'] = username
         pipelines_info = api.call(GET(
             '/projects/{project_id}/pipelines'.format(project_id=project_id),
             params,
@@ -32,15 +35,28 @@ class Pipeline(gitlab.Resource):
         return [cls(api, pipeline_info, project_id) for pipeline_info in pipelines_info]
 
     @classmethod
-    def pipelines_by_merge_request(cls, project_id, merge_request_iid, api):
+    def pipelines_by_merge_request(cls, project_id, merge_request_iid, api, username=None):
         """Fetch all pipelines for a merge request in descending order of pipeline ID."""
+        params = {}
+        if username is not None:
+            params['username'] = username
         pipelines_info = api.call(GET(
             '/projects/{project_id}/merge_requests/{merge_request_iid}/pipelines'.format(
                 project_id=project_id, merge_request_iid=merge_request_iid,
-            )
+            ),
+            params,
         ))
         pipelines_info.sort(key=lambda pipeline_info: pipeline_info['id'], reverse=True)
         return [cls(api, pipeline_info, project_id) for pipeline_info in pipelines_info]
+
+    @classmethod
+    def start(cls, project_id, branch, api):
+        """Start a new pipeline, return a Pipeline."""
+        response = api.call(POST(
+            '/projects/{project_id}/pipeline'.format(project_id=project_id),
+            {'ref': branch},
+        ))
+        return cls(api, response, project_id)
 
     @property
     def project_id(self):

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -37,7 +37,7 @@ class SingleMergeJob(MergeJob):
             merge_request.comment('Something seems broken on my local git repo; check my logs!')
             raise
         except error.SignalError:
-            raise # it's ok, propagate it
+            raise  # it's ok, propagate it
         except Exception:
             log.exception('Unexpected Exception')
             merge_request.comment("I'm broken on the inside, please somebody fix me... :cry:")

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -3,7 +3,9 @@ import logging as log
 import time
 from datetime import datetime
 
-from . import git, gitlab
+from . import error
+from . import git
+from . import gitlab
 from .commit import Commit
 from .job import CannotMerge, GitLabRebaseResultMismatch, MergeJob, SkipMerge
 
@@ -34,6 +36,8 @@ class SingleMergeJob(MergeJob):
             log.exception('Unexpected Git error')
             merge_request.comment('Something seems broken on my local git repo; check my logs!')
             raise
+        except error.SignalError:
+            raise # it's ok, propagate it
         except Exception:
             log.exception('Unexpected Exception')
             merge_request.comment("I'm broken on the inside, please somebody fix me... :cry:")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,7 +112,7 @@ def test_rebase_remotely():
 
 def test_use_merge_strategy():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
-        with main('--use-merge-strategy') as bot:
+        with main('--merge-strategy=merge') as bot:
             assert bot.config.merge_opts != job.MergeJobOptions.default()
             assert bot.config.merge_opts == job.MergeJobOptions.default(fusion=job.Fusion.merge)
 
@@ -127,7 +127,7 @@ def test_add_tested():
 def test_use_merge_strategy_and_add_tested_are_mutualy_exclusive():
     with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
         with pytest.raises(app.MargeBotCliArgError):
-            with main('--use-merge-strategy --add-tested'):
+            with main('--merge-strategy=merge --add-tested'):
                 pass
 
 
@@ -151,7 +151,7 @@ def test_add_reviewers():
 
 
 def test_rebase_remotely_option_conflicts():
-    for conflicting_flag in ['--use-merge-strategy', '--add-tested', '--add-part-of', '--add-reviewers']:
+    for conflicting_flag in ['--merge-strategy=merge', '--add-tested', '--add-part-of', '--add-reviewers']:
         with env(MARGE_AUTH_TOKEN="NON-ADMIN-TOKEN", MARGE_SSH_KEY="KEY", MARGE_GITLAB_URL='http://foo.com'):
             with pytest.raises(app.MargeBotCliArgError):
                 with main('--rebase-remotely %s' % conflicting_flag):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -247,6 +247,7 @@ class TestMergeJobOptions:
             approval_timeout=timedelta(seconds=0),
             embargo=marge.interval.IntervalUnion.empty(),
             ci_timeout=timedelta(minutes=15),
+            ci_timeout_skip=False,
             fusion=Fusion.rebase,
             use_no_ff_batches=False,
             use_merge_commit_batches=False,

--- a/tests/test_single_job.py
+++ b/tests/test_single_job.py
@@ -229,6 +229,7 @@ class TestUpdateAndAccept:  # pylint: disable=too-many-public-methods
                 marge.job.Fusion.rebase: 'rebase(%s onto %s)',
                 marge.job.Fusion.merge: 'merge(%s with %s)',
                 marge.job.Fusion.gitlab_rebase: 'rebase(%s onto %s)',
+                marge.job.Fusion.rebase_then_merge: 'rebase(%s onto %s)',
             }
             return pats[fusion] % (new, old)
         yield new_sha


### PR DESCRIPTION
- don't put the PRIVATE-TOKEN in the debug log
- add --require-ci-run-by-me
- install a signal handler so marge cleans up her tmp dir
- don't unassign on a SIGTERM, it's ok to restart and resume in that case
- Update logging to be more concise (#3)
- Fix lint errors
- Backport 840bd19 2020-07-01 nirizr/mr_roundrobin (#2)
- Add rebase_then_merge fusion strategy
